### PR TITLE
feat: add SystemVerilog examples for first-time users

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,57 @@
+# SystemVerilog Examples
+
+This directory contains example SystemVerilog files to demonstrate sv2svg functionality.
+
+## Example Files
+
+### `basic_gates.sv`
+Simple example showing basic logic gates (AND, OR, NOT) using gate instantiations.
+
+```bash
+sv2svg examples/basic_gates.sv -o basic_gates.svg
+```
+
+### `full_adder.sv`
+Complete 1-bit full adder implementation using XOR, AND, and OR gates. Referenced in the main README.
+
+```bash
+sv2svg examples/full_adder.sv --style blueprint --orientation vertical -o full_adder.svg
+```
+
+### `mux2to1.sv`
+2-to-1 multiplexer demonstrating conditional logic using basic gates.
+
+```bash
+sv2svg examples/mux2to1.sv --style midnight -o mux2to1.svg
+```
+
+### `complex_logic.sv`
+More comprehensive example showing all supported gate types: AND, OR, NAND, NOR, XOR, XNOR, NOT, BUF.
+
+```bash
+sv2svg examples/complex_logic.sv --style mono -o complex_logic.svg
+```
+
+### `assign_statements.sv`
+Demonstrates limited behavioral SystemVerilog support using simple assign statements that sv2svg can convert to gates.
+
+```bash
+sv2svg examples/assign_statements.sv --style classic -o assign_statements.svg
+```
+
+## Try Different Styles and Orientations
+
+Each example can be rendered with different visual styles:
+- `classic` - Dark blue-gray (default)
+- `blueprint` - NASA blue
+- `midnight` - Cyan on dark
+- `mono` - Grayscale
+
+And orientations:
+- `horizontal` - Left-to-right (default)
+- `vertical` - Top-to-bottom
+
+Example with all options:
+```bash
+sv2svg examples/full_adder.sv --style blueprint --orientation vertical --grid-x 10 --grid-y 10 --no-symmetry -o full_adder_custom.svg
+```

--- a/examples/assign_statements.sv
+++ b/examples/assign_statements.sv
@@ -1,0 +1,16 @@
+// Assign statements example
+// Demonstrates the limited behavioral SystemVerilog support
+
+module assign_statements(a, b, y_and, y_or, y_xor, y_nand, y_nor, y_xnor, y_not);
+  input logic a, b;
+  output logic y_and, y_or, y_xor, y_nand, y_nor, y_xnor, y_not;
+
+  // Simple two-input patterns that sv2svg can handle
+  assign y_and = a & b;
+  assign y_or = a | b;
+  assign y_xor = a ^ b;
+  assign y_nand = ~(a & b);
+  assign y_nor = ~(a | b);
+  assign y_xnor = ~(a ^ b);
+  assign y_not = ~a;
+endmodule

--- a/examples/basic_gates.sv
+++ b/examples/basic_gates.sv
@@ -1,0 +1,12 @@
+// Basic logic gates example
+// Demonstrates AND, OR, NOT gates using gate instantiations
+
+module basic_gates(a, b, y_and, y_or, y_not);
+  input logic a, b;
+  output logic y_and, y_or, y_not;
+
+  // Basic gates
+  AND u1(a, b, y_and);
+  OR u2(a, b, y_or);
+  NOT u3(a, y_not);
+endmodule

--- a/examples/complex_logic.sv
+++ b/examples/complex_logic.sv
@@ -1,0 +1,33 @@
+// Complex logic example
+// Demonstrates multiple gate types: AND, OR, NAND, NOR, XOR, XNOR, NOT, BUF
+
+module complex_logic(a, b, c, d, y1, y2, y3, y4, y5, y6);
+  input logic a, b, c, d;
+  output logic y1, y2, y3, y4, y5, y6;
+
+  logic a_buf, b_not, ab_and, cd_or, ab_nand, cd_nor, ac_xor, bd_xnor;
+
+  // Buffer and inverter
+  BUF u1(a, a_buf);
+  NOT u2(b, b_not);
+
+  // Basic gates
+  AND u3(a, b, ab_and);
+  OR u4(c, d, cd_or);
+
+  // NAND and NOR gates
+  NAND u5(a, b, ab_nand);
+  NOR u6(c, d, cd_nor);
+
+  // XOR and XNOR gates
+  XOR u7(a, c, ac_xor);
+  XNOR u8(b, d, bd_xnor);
+
+  // Complex combinations
+  AND u9(a_buf, b_not, y1);
+  OR u10(ab_and, cd_or, y2);
+  XOR u11(ab_nand, cd_nor, y3);
+  NAND u12(ac_xor, bd_xnor, y4);
+  NOR u13(y1, y2, y5);
+  XNOR u14(y3, y4, y6);
+endmodule

--- a/examples/full_adder.sv
+++ b/examples/full_adder.sv
@@ -1,0 +1,20 @@
+// Full adder example
+// Demonstrates a complete 1-bit full adder using basic gates
+
+module full_adder(a, b, cin, sum, cout);
+  input logic a, b, cin;
+  output logic sum, cout;
+
+  logic ab_xor, ab_and, ac_and, bc_and, ab_ac_or;
+
+  // Sum logic: sum = a ^ b ^ cin
+  XOR u1(a, b, ab_xor);
+  XOR u2(ab_xor, cin, sum);
+
+  // Carry out logic: cout = (a & b) | (a & cin) | (b & cin)
+  AND u3(a, b, ab_and);
+  AND u4(a, cin, ac_and);
+  AND u5(b, cin, bc_and);
+  OR u6(ab_and, ac_and, ab_ac_or);
+  OR u7(ab_ac_or, bc_and, cout);
+endmodule

--- a/examples/mux2to1.sv
+++ b/examples/mux2to1.sv
@@ -1,0 +1,20 @@
+// 2:1 Multiplexer example
+// Demonstrates a 2-to-1 multiplexer using basic gates
+// y = sel ? b : a
+
+module mux2to1(a, b, sel, y);
+  input logic a, b, sel;
+  output logic y;
+
+  logic sel_n, a_sel_n, b_sel;
+
+  // Invert select signal
+  NOT u1(sel, sel_n);
+
+  // AND gates for selection
+  AND u2(a, sel_n, a_sel_n);
+  AND u3(b, sel, b_sel);
+
+  // OR gate for output
+  OR u4(a_sel_n, b_sel, y);
+endmodule


### PR DESCRIPTION
This PR adds comprehensive SystemVerilog examples to help first-time users get started with sv2svg.

**What's included:**
- `basic_gates.sv` - Simple AND, OR, NOT gates
- `full_adder.sv` - 1-bit full adder (referenced in README)
- `mux2to1.sv` - 2-to-1 multiplexer
- `complex_logic.sv` - All supported gate types
- `assign_statements.sv` - Limited behavioral SystemVerilog
- `examples/README.md` - Usage instructions and examples

**Fixes:** #3

Generated with [Claude Code](https://claude.ai/code)