### PR TITLE
fix: prevent spurious file creation when using -o - for stdout

### DIFF
--- a/src/sv2svg/core.py
+++ b/src/sv2svg/core.py
@@ -648,9 +648,19 @@ class SVCircuit:
         if rotate_svg:
             svg_text = _rotate_svg_clockwise(svg_text, bbox)
 
+        # Return early for stdout output to avoid any file creation
         if to_stdout:
+            # Clean up any spurious files that schemdraw might have created
+            # with the "-" filename (workaround for schemdraw side effects)
+            for spurious_file in ['-', ' -', '-.svg', ' -.svg']:
+                if os.path.exists(spurious_file):
+                    try:
+                        os.remove(spurious_file)
+                    except OSError:
+                        pass  # Ignore errors
             return svg_text
 
+        # Only proceed with file operations if not writing to stdout
         ext = os.path.splitext(output_filename)[1].lower()
         if rotate_svg and ext not in ('.svg', ''):
             raise ValueError("Vertical orientation is only supported for SVG outputs.")


### PR DESCRIPTION
Fixes #8

This PR fixes an issue where a spurious file named ` -` (space-dash) was created when using `-o -` to output to stdout.

## Changes
- Added cleanup code in `generate_diagram()` to remove any spurious files that schemdraw's `get_imagedata()` method might create as side effects
- The cleanup handles multiple filename variations: `-`, ` -`, `-.svg`, ` -.svg`
- Only runs when `to_stdout=True` to avoid affecting normal file output operations

Generated with [Claude Code](https://claude.ai/code)