### PR TITLE
fix: restrict input/output parsing regex to valid identifiers

### DIFF
--- a/src/sv2svg/core.py
+++ b/src/sv2svg/core.py
@@ -450,11 +450,11 @@ class SVCircuit:
         self.port_order = [p.strip() for p in raw_ports.split(',') if p.strip()]
 
         for decl, target in (("input", self.inputs), ("output", self.outputs)):
-            for match in re.findall(rf"{decl}\s+(?:wire|logic)?\s*([^;]+);", content):
+            for match in re.findall(rf"{decl}\s+(?:wire|logic)?\s*([\w,\s]+);", content):
                 names = [x.strip() for x in match.split(',') if x.strip()]
                 target.extend(names)
 
-        for match in re.findall(r"logic\s+([^;]+);", content):
+        for match in re.findall(r"logic\s+([\w,\s]+);", content):
             names = [x.strip() for x in match.split(',') if x.strip()]
             self.internal_signals.update(names)
 


### PR DESCRIPTION
Fixes #11

The regex pattern `[^;]+` was too permissive and would match everything up to the next semicolon. When users omitted semicolons after port declarations (e.g., 'output logic y' without ';'), the pattern would incorrectly capture subsequent code like assign statements as part of the port name.

Changed patterns to `[\w,\s]+` which only matches word characters, commas, and whitespace, preventing the parser from treating non-port code as port names.

---

Generated with [Claude Code](https://claude.ai/code)