### PR TITLE
feat: add support for timing delays in assign statements

### DIFF
--- a/tests/fixtures/assign_timing.sv
+++ b/tests/fixtures/assign_timing.sv
@@ -1,0 +1,7 @@
+// Assign statement test - with timing delay
+module assign_timing(a, b, y);
+  input logic a, b;
+  output logic y;
+
+  assign #3 y = a | b;
+endmodule

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -74,6 +74,17 @@ class TestSVCircuitParsing:
         assert circuit.gates[0].type == "NOT"
         assert len(circuit.gates[0].inputs) == 1
 
+    def test_parse_assign_timing(self, fixture_dir):
+        """Test parsing assign statement with timing delay."""
+        circuit = SVCircuit()
+        circuit.parse_file(str(fixture_dir / "assign_timing.sv"))
+
+        assert circuit.module_name == "assign_timing"
+        assert len(circuit.gates) == 1
+        assert circuit.gates[0].type == "OR"
+        assert circuit.gates[0].output == "y"
+        assert circuit.gates[0].delay == "3"
+
     def test_parse_all_gate_types(self, fixture_dir):
         """Test parsing all supported gate types."""
         circuit = SVCircuit()


### PR DESCRIPTION
Fixes #13

## Summary
Adds support for timing delays in assign statements by parsing `#<time>` syntax and displaying the timing information as a label inside the gate.

## Changes
- Add optional `delay` field to Gate dataclass
- Modify assign statement regex to capture `#<time>` syntax
- Display timing labels inside gates at center position
- Add test fixture and test case for timing delay parsing

## Test Plan
- [ ] Run test suite: `pytest tests/`
- [ ] Verify `test_parse_assign_timing` passes
- [ ] Test with example file: `sv2svg tests/fixtures/assign_timing.sv -o output.svg`

Generated with [Claude Code](https://claude.ai/code)