### PR TITLE
fix: correct timing label vertical offset to move labels down

### DIFF
--- a/src/sv2svg/core.py
+++ b/src/sv2svg/core.py
@@ -1475,8 +1475,8 @@ class SVCircuit:
                 # Use smaller font (6pt minimum) and 't:' prefix
                 # Adjust vertical offset to center label text with gate center
                 label_fontsize = max(6, fontsize-3)
-                # Approximate vertical offset: move label up by ~40% of fontsize to center it
-                vertical_offset = label_fontsize * 0.04  # Schemdraw units
+                # Approximate vertical offset: move label down by ~4% of fontsize to center it
+                vertical_offset = -label_fontsize * 0.04  # Schemdraw units (negative moves down)
                 elem.label(f't:{g.delay}', 'center', fontsize=label_fontsize, ofst=(0, vertical_offset))
             return elem
 


### PR DESCRIPTION
## Summary

Fixed timing label positioning bug where labels were moving up instead of down.

## Changes

- Corrected vertical offset sign in `src/sv2svg/core.py` line 1479
- Labels now properly move down to center within gates

Closes #19

Generated with [Claude Code](https://claude.ai/code)